### PR TITLE
[test] #33 코드리뷰용 PR

### DIFF
--- a/src/main/java/com/springmvc/unid/controller/NotifyController.java
+++ b/src/main/java/com/springmvc/unid/controller/NotifyController.java
@@ -1,7 +1,7 @@
 package com.springmvc.unid.controller;
 
 import com.springmvc.unid.controller.dto.request.RequestCreateNotifyDto;
-import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.controller.dto.NotifyDto;
 import com.springmvc.unid.service.NotifyService;
 import com.springmvc.unid.util.api.ApiResponse;
 import com.springmvc.unid.util.exception.ResponseCode;
@@ -23,7 +23,7 @@ public class NotifyController {
         return ApiResponse.success(notifyDtoList, ResponseCode.NOTIFY_READ_SUCCESS.getMessage());
     }
 
-    // user가 알림을 생성하여 특정 user(들) 에게 전송
+    // user가 알림을 생성하여 특정 user(들)에게 전송
     @PostMapping("/api/notifies")
     public ApiResponse<Long> notifySend(@RequestBody RequestCreateNotifyDto notifyDto){
         notifyService.create(notifyDto.getReceiverIds(), notifyDto.getNotifyDto());

--- a/src/main/java/com/springmvc/unid/controller/TeamController.java
+++ b/src/main/java/com/springmvc/unid/controller/TeamController.java
@@ -71,7 +71,7 @@ public class TeamController {
         return ApiResponse.success(teamMembers, ResponseCode.TEAM_READ_SUCCESS.getMessage());
     }
 
-    // user의 대학의 팀 조회
+    // user의 소속 대학의 팀 조회
     @GetMapping("/api/teams/univ")
     public ApiResponse<List<TeamDto>> getTeamListByUniv(@RequestBody RequestUnivMemberDto universityDto){
         List<TeamDto> teamDtoList = teamService.findTeamByUniv(universityDto.getUniversity());

--- a/src/main/java/com/springmvc/unid/controller/UserController.java
+++ b/src/main/java/com/springmvc/unid/controller/UserController.java
@@ -3,7 +3,7 @@ package com.springmvc.unid.controller;
 import com.springmvc.unid.controller.dto.TeamDto;
 import com.springmvc.unid.controller.dto.UserDto;
 import com.springmvc.unid.controller.dto.request.*;
-import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.controller.dto.NotifyDto;
 import com.springmvc.unid.service.NotifyService;
 import com.springmvc.unid.service.TeamService;
 import com.springmvc.unid.service.UserService;
@@ -66,7 +66,7 @@ public class UserController {
         return ApiResponse.success(teamDtoList, ResponseCode.TEAM_READ_SUCCESS.getMessage());
     }
 
-    // user가 현재 소속된 팀에서 탈퇴 (팀장이 아닌 팀원만 가능)
+    // user가 현재 소속된 팀에서 탈퇴 (팀장은 불가능)
     @PostMapping("/api/users/{id}/teams/leave")
     public ApiResponse<Long> leaveTeam(@PathVariable("id") Long id, @RequestBody RequestExitTeamDto requestExitTeamDto){
         teamService.leaveTeam(id, requestExitTeamDto.getTeamId());

--- a/src/main/java/com/springmvc/unid/controller/dto/NotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/NotifyDto.java
@@ -1,13 +1,9 @@
-package com.springmvc.unid.controller.dto.response;
+package com.springmvc.unid.controller.dto;
 
 import com.springmvc.unid.domain.Notify;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * ResponseNotifyDto의 용도
- * 알림 조회 결과 객체 (response)
- */
 @Data
 @NoArgsConstructor
 public class NotifyDto {

--- a/src/main/java/com/springmvc/unid/controller/dto/RequirementDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/RequirementDto.java
@@ -4,13 +4,6 @@ import com.springmvc.unid.domain.Requirement;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * RequirementDto의 용도
- * 1. 팀장이 파트별 요구사항 추가 request/response
- * 2. 팀장이 파트별 요구사항 수정 request/response
- * 3. 팀장이 파트별 요구사항 삭제 request/response
- * 4. 팀장이 파트별 요구사항 조회 결과 response
- */
 @Data
 @NoArgsConstructor
 public class RequirementDto {

--- a/src/main/java/com/springmvc/unid/controller/dto/TeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/TeamDto.java
@@ -8,13 +8,6 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
-/**
- * TeamDto의 용도
- * 1. 팀 생성 Request/Response
- * 2. 팀 정보 수정 Request/Response
- * 3. 팀 조회 결과 Response
- * 4. 팀 삭제 Request/Response
- */
 @Data
 @NoArgsConstructor
 public class TeamDto {

--- a/src/main/java/com/springmvc/unid/controller/dto/UserDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/UserDto.java
@@ -4,14 +4,6 @@ import com.springmvc.unid.domain.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * UserDto의 용도
- * 1. 회원가입 Request/Response
- * 2. 로그인 성공 시 서버가 클라이언트에게 보내는 Response
- * 3. 회원정보 수정 Request/Response
- * 4. user 조회 결과 Response
- * 5. user가 받은 알림 조회를 위해 클라이언트가 서버에게 보내는 Request
- */
 @Data
 @NoArgsConstructor
 public class UserDto {

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateNotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateNotifyDto.java
@@ -1,6 +1,6 @@
 package com.springmvc.unid.controller.dto.request;
 
-import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.controller.dto.NotifyDto;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateTeamDto.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 public class RequestCreateTeamDto { // 팀 생성 요청
+
     private String name;
     private String user;
     private String oneLine;

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateUserDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateUserDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class RequestCreateUserDto { // 회원가입 요청
+
     private String loginId;
     private String pw;
     private String name;

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteNotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteNotifyDto.java
@@ -6,5 +6,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class RequestDeleteNotifyDto {
+
     private Long notifyId; // 알림의 id
+
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteRequirementDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteRequirementDto.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestDeleteRequirementDto { // 팀 요구사항 삭제 요청
+public class RequestDeleteRequirementDto { // 팀의 요구사항 삭제 요청
     private Long requirementId;
     private Long userId;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestExitTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestExitTeamDto.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestExitTeamDto { // 팀 탈퇴 요청
+public class RequestExitTeamDto { // 팀에서 탈퇴 요청
     private Long teamId;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestJoinTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestJoinTeamDto.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestJoinTeamDto { // 팀 가입 요청
+public class RequestJoinTeamDto { // 팀에 가입 요청
     private Long teamId;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestLoginDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestLoginDto.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestLoginDto { // 로그인 요청
+public class RequestLoginDto { // 회원 로그인 요청
     private String loginId;
     private String pw;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUnivMemberDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUnivMemberDto.java
@@ -5,6 +5,6 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestUnivMemberDto { // 대학 내 팀 조회 등을 위한 대학명 요청
+public class RequestUnivMemberDto { // 대학명 요청 (대학 소속 팀 목록 조회를 위함)
     private String university;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamDto.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestUpdateTeamDto { // 팀 정보 수정 요청
+public class RequestUpdateTeamDto { // 팀의 정보 수정 요청
     private TeamDto teamDto;
     private Long userId;
 }

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamLeaderDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamLeaderDto.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class RequestUpdateTeamLeaderDto { // 팀장 변경 요청
+public class RequestUpdateTeamLeaderDto { // 팀의 팀장 변경 요청
     private Long leaderId;
     private Long nextId;
 }

--- a/src/main/java/com/springmvc/unid/domain/Notify.java
+++ b/src/main/java/com/springmvc/unid/domain/Notify.java
@@ -20,7 +20,7 @@ public class Notify {
     @Column(name = "notify_id")
     private Long id;
 
-    private Long type; // 알림의 종류
+    private Long type; // 알림 종류
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/springmvc/unid/domain/Requirement.java
+++ b/src/main/java/com/springmvc/unid/domain/Requirement.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 @Setter @Getter
 @Table(name = "requirement")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Requirement {
+public class Requirement { // 팀-요구사항은 1대다 관계
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "requirement_id")

--- a/src/main/java/com/springmvc/unid/domain/Team.java
+++ b/src/main/java/com/springmvc/unid/domain/Team.java
@@ -25,7 +25,6 @@ public class Team {
 
     private String name; // 팀 이름
 
-    // 각 팀 테이블은 팀장의 id를 외래키로 가짐
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // 팀장

--- a/src/main/java/com/springmvc/unid/domain/TeamMember.java
+++ b/src/main/java/com/springmvc/unid/domain/TeamMember.java
@@ -26,7 +26,7 @@ public class TeamMember { // Team과 User의 다대다 관계로 인해 생성�
     @JoinColumn(name = "user_id")
     private User user; // 사용자 id - 외래키
 
-    private LocalDate joinDate; // 팀 가입일
+    private LocalDate joinDate; // 팀 가입 날짜
 
     // 생성 메서드
     public static TeamMember createTeamMember(Team team, User user, LocalDate joinDate) {

--- a/src/main/java/com/springmvc/unid/domain/User.java
+++ b/src/main/java/com/springmvc/unid/domain/User.java
@@ -22,7 +22,7 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    private String loginId; // 사용자 id
+    private String loginId; // 유저 id
 
     private String name; // 사용자 별명
 

--- a/src/main/java/com/springmvc/unid/domain/UserNotify.java
+++ b/src/main/java/com/springmvc/unid/domain/UserNotify.java
@@ -20,7 +20,7 @@ public class UserNotify { // User와 Notify의 다대다 관계로 인해 생성
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    private User user; // 수신자
+    private User user; // 수신 유저
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notify_id")

--- a/src/main/java/com/springmvc/unid/repository/NotifyRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/NotifyRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface NotifyRepository extends JpaRepository<Notify, Long> {
+
     // 알림 생성 -> save(Notify notify)
 
     // 알림 조회

--- a/src/main/java/com/springmvc/unid/repository/TeamMemberRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/TeamMemberRepository.java
@@ -17,7 +17,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     // 특정 팀의 소속 user 조회
     List<TeamMember> findByTeam(Team team);
 
-    // user가 팀에 가입 - save
+    // user가 팀에 가입 -> save
 
     // user가 팀에서 탈퇴
     void delete(TeamMember teamMember);

--- a/src/main/java/com/springmvc/unid/repository/TeamRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/TeamRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    // 팀 생성 및 수정 -> save(Team team)
 
     // 팀 조회
     Optional<Team> findById(Long id);

--- a/src/main/java/com/springmvc/unid/repository/UserNotifyRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/UserNotifyRepository.java
@@ -18,10 +18,6 @@ public interface UserNotifyRepository extends JpaRepository<UserNotify, Long> {
     // user가 받은 알림 조회
     List<UserNotify> findByUser(User user);
 
-    // 특정 user에게 특정 알림 전송 - save(UserNotify userNotify);
-
-    // user가 알림 삭제 - deleteById(Long id);
-
     // 특정 유저가 알림을 이미 받았는지 확인하기 위한 조회
     Optional<UserNotify> findByUserAndNotify(User user, Notify notify);
 }

--- a/src/main/java/com/springmvc/unid/repository/UserRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/UserRepository.java
@@ -9,9 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    // 회원 가입 및 정보 수정 - save(User user)
 
-    // id로 회원 조회
     Optional<User> findById(Long Id);
 
     // name으로 회원 조회

--- a/src/main/java/com/springmvc/unid/service/NotifyService.java
+++ b/src/main/java/com/springmvc/unid/service/NotifyService.java
@@ -1,7 +1,7 @@
 package com.springmvc.unid.service;
 
 import com.springmvc.unid.controller.dto.UserDto;
-import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.controller.dto.NotifyDto;
 import com.springmvc.unid.domain.Notify;
 import com.springmvc.unid.domain.Team;
 import com.springmvc.unid.domain.User;
@@ -76,7 +76,7 @@ public class NotifyService {
         return notifyDtos;
     }
 
-    // user에게 알림을 전송
+    // user에게 알림 전송
     @Transactional
     public void sendNotify(User user, Notify notify){
         UserNotify userNotify = UserNotify.createUserNotify(user, notify, LocalDate.now());

--- a/src/main/java/com/springmvc/unid/service/TeamService.java
+++ b/src/main/java/com/springmvc/unid/service/TeamService.java
@@ -132,7 +132,7 @@ public class TeamService {
         return new UserDto(team.getUser());
     }
 
-    // 팀에 특정 팀원 가입
+    // 팀에 팀원 가입
     @Transactional
     public void joinTeam(Long userId, Long teamId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));

--- a/src/main/java/com/springmvc/unid/service/UserService.java
+++ b/src/main/java/com/springmvc/unid/service/UserService.java
@@ -95,23 +95,4 @@ public class UserService {
         return teamDtos;
     }
 
-    /*// 특정 알림을 받은 user 조회
-    public List<User> findUsersByUserNotify(Notify notify) {
-        List<User> users = new ArrayList<>();
-        List<UserNotify> userNotifies = userNotifyRepository.findByNotify(notify);
-        for (UserNotify userNotify : userNotifies) {
-            users.add(userNotify.getUser());
-        }
-        return users;
-    } */
-
-    /*// 특정 대학에 소속된 user 조회
-    public List<UserDto> findUsersByUniversity(String university) {
-        List<User> users = userRepository.findByUniversity(university);
-        List<UserDto> userDtos = new ArrayList<>();
-        for (User user : users) {
-            userDtos.add(new UserDto(user));
-        }
-        return userDtos;
-    }*/
 }

--- a/src/main/java/com/springmvc/unid/util/api/ApiBody.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiBody.java
@@ -1,5 +1,6 @@
 package com.springmvc.unid.util.api;
 
+// 응답 바디
 public class ApiBody<T> {
     private final T data;
     private final T msg;

--- a/src/main/java/com/springmvc/unid/util/api/ApiHeader.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiHeader.java
@@ -1,5 +1,6 @@
 package com.springmvc.unid.util.api;
 
+// 응답 헤더
 public class ApiHeader {
     private final int resultCode;
     private final String codeName;

--- a/src/main/java/com/springmvc/unid/util/api/ApiResponse.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiResponse.java
@@ -5,6 +5,7 @@ import com.springmvc.unid.util.exception.ResponseCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+// 응답 객체
 @Getter
 @RequiredArgsConstructor
 public class ApiResponse<T> {

--- a/src/main/java/com/springmvc/unid/util/exception/CustomException.java
+++ b/src/main/java/com/springmvc/unid/util/exception/CustomException.java
@@ -3,6 +3,7 @@ package com.springmvc.unid.util.exception;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+// 응답 코드를 담은 CustomException
 @AllArgsConstructor
 @Getter
 public class CustomException extends RuntimeException {

--- a/src/main/java/com/springmvc/unid/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/springmvc/unid/util/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.springmvc.unid.util.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
+// 전역 예외 처리 (아직 잘 알지 못해 미구현)
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/com/springmvc/unid/util/exception/ResponseCode.java
+++ b/src/main/java/com/springmvc/unid/util/exception/ResponseCode.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+// 응답 코드와 응답 메시지를 정의한 enum 클래스
 @AllArgsConstructor(access =  AccessLevel.PRIVATE)
 @Getter
 public enum ResponseCode {

--- a/src/test/java/com/springmvc/unid/service/NotifyServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/NotifyServiceTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
+// #33 테스트 코드 수정 필요
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/springmvc/unid/service/TeamServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/TeamServiceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
+// #33 테스트 코드 수정 필요
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/springmvc/unid/service/UserServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/UserServiceTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import static org.junit.Assert.*;
 
+// #33 테스트 코드 수정 필요
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
# 프로젝트 기간(7/1 ~7/14)
* Springboot(Java 11)과 mySQL을 활용한, User-Team-Notify의 주요 3요소로 구성된 프로젝트입니다.
* 유저는 팀에 가입하기 위해 팀장에게 알림을 보낼 수 있고, 팀장은 이에 답장할 수 있습니다. 물론 팀을 탈퇴할 수도 있습니다.
* Notify는 일종의 메일함..을 구현하고자 노력했는데, 초반 설계가 미흡해 Team이 외래키로 잘못 포함되는 바람에 의존성이 크게 늘어나는 문제가 있었습니다.
* 팀은 각 파트별 구인 요구사항을 작성, 수정, 삭제할 수 있습니다.

# 문제점
* 솔로 프로젝트여서 util-controller-service-repository-exception-domain으로 구성되는 패키지를 단일로 설정했습니다. 다른 팀원들과 협업할 때는 주요 기능별로 분리하는 것이 바람직하다고 인지하고 있습니다.
* Controller가 Service를 여러 개 가지는(의존하는) 것이 바람직한지, 아니면 Service가 여러 Repository를 가지는 것이 바람직한지 잘 모르겠습니다. 계층별 역할에 대한 구체적인 고민이 부재했던 프로젝트였습니다. 그 탓에 Service별로 중복되는 Repository가 많습니다.
* Domain-Repository-Service-Test-Dto-Exception-Controller 순으로 독학하면서 진행했는데, Controller에서 클라이언트에게 요청 받아서 사용될 Dto에 대해 고민하지 않아서 Service의 매개변수 등을 대폭 수정해야 했던 문제점이 있었습니다.
* 중간에 김영한 강사님의 JPA 강의를 수강하고 다시 재개했는데, Dto -> Entity를 Controller에서 진행하셨습니다. 우테코나 실무에서는 Dto -> Entity나 Entity -> Dto를 Service에서 주로 하는지, Controller에서 주로 하는지 알고 싶습니다.
<img width="975" alt="image" src="https://github.com/win-luck/UniD_API/assets/53044069/ce40c8c3-5da4-42f5-92eb-d0809a521791">
* 또한 위와 같이 Controller에서 보시면 알 수 있듯이, 값을 반환하는 메서드에 대해 null이 반환되었을 때(즉 팀이 존재하지 않을 때) 에 대한 예외처리를 Controller에서 처리하지 않고 Service의 CumstomException을 활용해 보다 더 깔끔하게 처리하여 클라이언트에게 관련 메시지를 전달하고 싶은데, 바람직한 방법을 찾고 있습니다.
<img width="939" alt="image" src="https://github.com/win-luck/UniD_API/assets/53044069/47bf7755-61e9-4cad-8142-39202207116d">
* 그리고 다대다 관계로 인해 생성되는 중간 테이블에 대한 정보를 확인해야 할 때, (예를 들어 user가 받은 notify 조회, user가 소속된 team 조회) 기능 구현을 위해 다른 Service까지 끌고 왔는데, Service에 관련 Repository를 보강하고 추가적인 Service를 없애는 게 나을까요? 즉 위에서 언급드린 대로 Controller가 의존하는 Service는 줄이고, 대신 Service가 의존하는 Repository를 늘리는 게 더 나은지 알고 싶습니다.
* 클라이언트에 대한 구체적인 생각 없이 (이렇게 보내줄 것이다~)라고 간주하고 시작했던 프로젝트였지만, 앞으로 프런트엔드와 소통하면서 협업해야 할 일이 많을 텐데, 우테코는 매주 과제에서 프런트엔드와 협업하는 것으로 알고 있습니다. 조언 주시면 감사하겠습니다:)