### PR TITLE
[chore] 코드리뷰 Pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.DS_Store
+
+application-mysql.properties

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,18 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'junit:junit:4.13.1'
+	testImplementation 'junit:junit:4.13.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+
+	// jdbc와 jpa 관련 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'mysql:mysql-connector-java:8.0.32'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/springmvc/unid/common/Pair.java
+++ b/src/main/java/com/springmvc/unid/common/Pair.java
@@ -1,0 +1,14 @@
+package com.springmvc.unid.common;
+
+import lombok.Getter;
+
+@Getter
+public class Pair { // Pair 객체 구현
+    private final String X;
+    private final Long Y;
+
+    public Pair(String X, Long Y) {
+        this.X = X;
+        this.Y = Y;
+    }
+}

--- a/src/main/java/com/springmvc/unid/common/notifyType.java
+++ b/src/main/java/com/springmvc/unid/common/notifyType.java
@@ -1,0 +1,9 @@
+package com.springmvc.unid.common;
+
+public enum notifyType {
+    application, // 팀원후보 -> 팀장, 지원서 신청
+    approval, // 팀장 -> 팀원후보, 지원 승인(팀 합류 허용)
+    reject, // 팀장 -> 팀원후보, 지원 거절
+    teamOut, // 팀원 -> 자신을 제외한 모든 팀원, 프로젝트 탈퇴
+    teamDelete // 팀장 -> 자신을 제외한 모든 팀원, 프로젝트 종료
+}

--- a/src/main/java/com/springmvc/unid/controller/NotifyController.java
+++ b/src/main/java/com/springmvc/unid/controller/NotifyController.java
@@ -1,0 +1,33 @@
+package com.springmvc.unid.controller;
+
+import com.springmvc.unid.controller.dto.request.RequestCreateNotifyDto;
+import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.service.NotifyService;
+import com.springmvc.unid.util.api.ApiResponse;
+import com.springmvc.unid.util.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NotifyController {
+
+    private final NotifyService notifyService;
+
+    // 전체 알림 조회
+    @GetMapping("/api/notifies")
+    public ApiResponse<List<NotifyDto>> getNotifyList(){
+        List<NotifyDto> notifyDtoList = notifyService.findAll();
+        return ApiResponse.success(notifyDtoList, ResponseCode.NOTIFY_READ_SUCCESS.getMessage());
+    }
+
+    // user가 알림을 생성하여 특정 user(들) 에게 전송
+    @PostMapping("/api/notifies")
+    public ApiResponse<Long> notifySend(@RequestBody RequestCreateNotifyDto notifyDto){
+        notifyService.create(notifyDto.getReceiverIds(), notifyDto.getNotifyDto());
+        return ApiResponse.success(1L, ResponseCode.NOTIFY_CREATE_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/controller/TeamController.java
+++ b/src/main/java/com/springmvc/unid/controller/TeamController.java
@@ -1,0 +1,116 @@
+package com.springmvc.unid.controller;
+
+import com.springmvc.unid.controller.dto.RequirementDto;
+import com.springmvc.unid.controller.dto.TeamDto;
+import com.springmvc.unid.controller.dto.UserDto;
+import com.springmvc.unid.controller.dto.request.*;
+import com.springmvc.unid.service.TeamService;
+import com.springmvc.unid.service.UserService;
+import com.springmvc.unid.util.api.ApiResponse;
+import com.springmvc.unid.util.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+    private final UserService userService;
+
+    // 팀 생성 (+ 팀장으로 등록, 중복 팀 생성 방지 포함)
+    @PostMapping("/api/teams")
+    public ApiResponse<Long> createTeam(@RequestBody RequestCreateTeamDto teamDto){
+        Long id = teamService.createTeam(teamDto);
+        return ApiResponse.success(id, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // 전체 팀 조회
+    @GetMapping("/api/teams")
+    public ApiResponse<List<TeamDto>> getTeamList(){
+        List<TeamDto> teamDtoList = teamService.findAll();
+        return ApiResponse.success(teamDtoList, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // 팀 정보 수정 (팀장만 가능)
+    @PostMapping("/api/teams/{id}")
+    public ApiResponse<Long> updateTeam(@PathVariable("id") Long id, @RequestBody RequestUpdateTeamDto requestUpdateTeamDto){
+        Long uid = teamService.update(id, requestUpdateTeamDto.getTeamDto(), requestUpdateTeamDto.getUserId());
+        if(uid == null) return ApiResponse.fail(ResponseCode.NOT_TEAM_LEADER); // 팀장 아님
+        return ApiResponse.success(uid, ResponseCode.TEAM_UPDATE_SUCCESS.getMessage());
+    }
+
+    // 팀 삭제 (팀장만 가능)
+    @DeleteMapping("/api/teams/{id}")
+    public ApiResponse<Long> deleteTeam(@PathVariable("id") Long id, @RequestBody Long userId){
+        teamService.deleteTeam(id, userId);
+        return ApiResponse.success(1L, ResponseCode.TEAM_DELETE_SUCCESS.getMessage());
+    }
+
+    // 특정 팀 조회
+    @GetMapping("/api/teams/{id}")
+    public ApiResponse<TeamDto> getTeamInfo(@PathVariable("id") Long id){
+        TeamDto teamDto = teamService.findOne(id);
+        if(teamDto == null) return ApiResponse.fail(ResponseCode.TEAM_NOT_FOUND);
+        return ApiResponse.success(teamDto, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 팀장 조회
+    @GetMapping("/api/teams/{id}/leader")
+    public ApiResponse<UserDto> getTeamLeader(@PathVariable("id") Long id){
+        UserDto teamLeader = teamService.findTeamLeader(id);
+        return ApiResponse.success(teamLeader, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 팀원 조회
+    @GetMapping("/api/teams/{id}/members")
+    public ApiResponse<List<UserDto>> getTeamMember(@PathVariable("id") Long id){
+        List<UserDto> teamMembers = teamService.findTeamMember(id);
+        return ApiResponse.success(teamMembers, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // user의 대학의 팀 조회
+    @GetMapping("/api/teams/univ")
+    public ApiResponse<List<TeamDto>> getTeamListByUniv(@RequestBody RequestUnivMemberDto universityDto){
+        List<TeamDto> teamDtoList = teamService.findTeamByUniv(universityDto.getUniversity());
+        return ApiResponse.success(teamDtoList, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // user가 팀장인 팀 조회
+    @GetMapping("/api/users/{id}/teams/leader")
+    public ApiResponse<List<TeamDto>> getLeaderTeamList(@PathVariable("id") Long id){
+        List<TeamDto> teamDtoList = teamService.findTeamByLeader(userService.findOne(id));
+        return ApiResponse.success(teamDtoList, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 팀장 변경 (팀장만 가능)
+    @PostMapping("/api/teams/{id}/leader")
+    public ApiResponse<Long> changeLeader(@PathVariable("id") Long id, @RequestBody RequestUpdateTeamLeaderDto requestUpdateTeamLeaderDto){
+        teamService.setTeamLeader(requestUpdateTeamLeaderDto.getLeaderId(), requestUpdateTeamLeaderDto.getNextId(), id);
+        return ApiResponse.success(id, ResponseCode.TEAM_UPDATE_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 구인 요구사항 추가 (팀장만 가능)
+    @PostMapping("/api/teams/{id}/require/add")
+    public ApiResponse<Long> addRequire(@PathVariable("id") Long id, @RequestBody RequirementDto requirementDto){
+        teamService.addRequirement(id, requirementDto);
+        return ApiResponse.success(id, ResponseCode.REQUIREMENT_UPDATE_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 구인 요구사항 수정 (팀장만 가능)
+    @PostMapping("/api/teams/{id}/require/update")
+    public ApiResponse<Long> updateRequire(@PathVariable("id") Long id, @RequestBody RequirementDto requirementDto){
+        teamService.updateRequirement(id, requirementDto.getRequirementId(), requirementDto);
+        return ApiResponse.success(id, ResponseCode.REQUIREMENT_UPDATE_SUCCESS.getMessage());
+    }
+
+    // 특정 팀의 구인 요구사항 제거 (팀장만 가능)
+    @PostMapping("/api/teams/{id}/require/delete")
+    public ApiResponse<Long> deleteRequire(@PathVariable("id") Long id, @RequestBody RequestDeleteRequirementDto requestDeleteRequirementDto){
+        teamService.deleteRequirement(id, requestDeleteRequirementDto.getRequirementId(), requestDeleteRequirementDto.getUserId());
+        return ApiResponse.success(id, ResponseCode.REQUIREMENT_DELETE_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/controller/UserController.java
+++ b/src/main/java/com/springmvc/unid/controller/UserController.java
@@ -1,0 +1,118 @@
+package com.springmvc.unid.controller;
+
+import com.springmvc.unid.controller.dto.TeamDto;
+import com.springmvc.unid.controller.dto.UserDto;
+import com.springmvc.unid.controller.dto.request.*;
+import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.service.NotifyService;
+import com.springmvc.unid.service.TeamService;
+import com.springmvc.unid.service.UserService;
+import com.springmvc.unid.util.api.ApiResponse;
+import com.springmvc.unid.util.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+    private final TeamService teamService;
+    private final NotifyService notifyService;
+
+    // 로그인 V
+    @PostMapping("/api/users/login")
+    public ApiResponse<Long> login(@RequestBody RequestLoginDto requestLoginDto){
+        Long id = userService.login(requestLoginDto.getLoginId(), requestLoginDto.getPw());
+        if(id == null) return ApiResponse.fail(ResponseCode.USER_LOGIN_FAILED);
+        return ApiResponse.success(id, ResponseCode.SIGNIN_SUCCESS.getMessage());
+    }
+
+    // 회원가입(+중복 user 방지) V
+    @PostMapping("/api/users")
+    public ApiResponse<Long> join(@RequestBody RequestCreateUserDto userDto){
+        Long id = userService.join(userDto);
+        if(id == null) return ApiResponse.fail(ResponseCode.DUPLICATED_USER);
+        return ApiResponse.success(id, ResponseCode.SIGNUP_SUCCESS.getMessage());
+    }
+
+    // 회원 탈퇴 V
+    @DeleteMapping("/api/users/{id}")
+    public ApiResponse<Long> delete(@PathVariable Long id){
+        userService.delete(id);
+        return ApiResponse.success(1L, ResponseCode.USER_DELETE_SUCCESS.getMessage());
+    }
+
+    // 회원 정보 수정 V
+    @PostMapping("/api/users/{id}")
+    public ApiResponse<Long> update(@PathVariable("id") Long id, @RequestBody UserDto userDto){
+        userService.update(id, userDto.getName(), userDto.getUniversity(), userDto.getMajor(), userDto.getLink());
+        return ApiResponse.success(1L, ResponseCode.USER_UPDATE_SUCCESS.getMessage());
+    }
+
+    // user가 특정 팀에 가입
+    @PostMapping("/api/users/{id}/teams")
+    public ApiResponse<Long> joinTeam(@PathVariable("id") Long id, @RequestBody RequestJoinTeamDto requestJoinTeamDto){
+        teamService.joinTeam(id, requestJoinTeamDto.getTeamId());
+        return ApiResponse.success(requestJoinTeamDto.getTeamId(), ResponseCode.TEAM_JOIN_SUCCESS.getMessage());
+    }
+
+    // user가 현재 소속된 팀 조회
+    @GetMapping("/api/users/{id}/teams")
+    public ApiResponse<List<TeamDto>> getTeamList(@PathVariable("id") Long id){
+        List<TeamDto> teamDtoList = teamService.findTeamByUser(userService.findOne(id));
+        return ApiResponse.success(teamDtoList, ResponseCode.TEAM_READ_SUCCESS.getMessage());
+    }
+
+    // user가 현재 소속된 팀에서 탈퇴 (팀장이 아닌 팀원만 가능)
+    @PostMapping("/api/users/{id}/teams/leave")
+    public ApiResponse<Long> leaveTeam(@PathVariable("id") Long id, @RequestBody RequestExitTeamDto requestExitTeamDto){
+        teamService.leaveTeam(id, requestExitTeamDto.getTeamId());
+        return ApiResponse.success(requestExitTeamDto.getTeamId(), ResponseCode.TEAM_LEAVE_SUCCESS.getMessage());
+    }
+
+    // user가 자신이 받은 알림을 조회
+    @GetMapping("/api/users/{id}/notifies")
+    public ApiResponse<Long> notify(@PathVariable("id") Long id){
+        List<NotifyDto> notifyDtoList = notifyService.findAllByUser(userService.findOne(id));
+        return ApiResponse.success(1L, ResponseCode.NOTIFY_READ_SUCCESS.getMessage());
+    }
+
+    // user가 자신이 보낸 알림을 조회
+    @GetMapping("/api/users/{id}/notifies/sent")
+    public ApiResponse<Long> notifySent(@PathVariable("id") Long id){
+        List<NotifyDto> notifyDtoList = notifyService.findAllBySender(userService.findOne(id));
+        return ApiResponse.success(1L, ResponseCode.NOTIFY_READ_SUCCESS.getMessage());
+    }
+
+    // user가 자신이 받은 알림을 삭제
+    @PostMapping("/api/users/{id}/notifies")
+    public ApiResponse<Long> deleteMyNotify(@PathVariable("id") Long id, @RequestBody RequestDeleteNotifyDto requestDeleteNotifyDto){
+        notifyService.deleteNotify(id, requestDeleteNotifyDto.getNotifyId());
+        return ApiResponse.success(1L, ResponseCode.NOTIFY_DELETE_SUCCESS.getMessage());
+    }
+
+
+    // 회원 정보 조회 V
+    @GetMapping("/api/users/{id}")
+    public ApiResponse<UserDto> find(@PathVariable Long id){
+        UserDto userDto = userService.findOne(id);
+        return ApiResponse.success(userDto, ResponseCode.USER_READ_SUCCESS.getMessage());
+    }
+
+    // 전체 회원 조회 V
+    @GetMapping("/api/users")
+    public ApiResponse<List<UserDto>> findAll(){
+        return ApiResponse.success(userService.findUsers(), ResponseCode.USER_READ_SUCCESS.getMessage());
+    }
+
+    /* 특정 대학에 소속된 회원 조회 : 필요성이 떨어져 보류
+    @GetMapping("/api/users/{id}/")
+    public ApiResponse<List<UserDto>> findByUniversity(@RequestBody String university){
+        return ApiResponse.success(userService.findUsersByUniversity(university));
+    }*/
+
+    // 특정 알림을 받은 user 조회 : 마찬가지로 보류
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/RequirementDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/RequirementDto.java
@@ -1,0 +1,31 @@
+package com.springmvc.unid.controller.dto;
+
+import com.springmvc.unid.domain.Requirement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * RequirementDto의 용도
+ * 1. 팀장이 파트별 요구사항 추가 request/response
+ * 2. 팀장이 파트별 요구사항 수정 request/response
+ * 3. 팀장이 파트별 요구사항 삭제 request/response
+ * 4. 팀장이 파트별 요구사항 조회 결과 response
+ */
+@Data
+@NoArgsConstructor
+public class RequirementDto {
+
+    private Long requirementId;
+    private String position;
+    private Long teamId;
+    private Long n;
+    private String requireContents;
+
+    public RequirementDto(Requirement requirement) {
+        this.requirementId = requirement.getId();
+        this.position = requirement.getPosition();
+        this.teamId = requirement.getTeam().getId();
+        this.n = requirement.getN();
+        this.requireContents = requirement.getRequireContents();
+    }
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/TeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/TeamDto.java
@@ -1,0 +1,41 @@
+package com.springmvc.unid.controller.dto;
+
+import com.springmvc.unid.domain.Team;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * TeamDto의 용도
+ * 1. 팀 생성 Request/Response
+ * 2. 팀 정보 수정 Request/Response
+ * 3. 팀 조회 결과 Response
+ * 4. 팀 삭제 Request/Response
+ */
+@Data
+@NoArgsConstructor
+public class TeamDto {
+
+    private Long teamId;
+    private String name;
+    private String leader;
+    private String oneLine;
+    private String description;
+    private String university;
+    private String link;
+    private List<RequirementDto> requirementList;
+
+    public TeamDto(Team team) {
+        this.teamId = team.getId();
+        this.name = team.getName();
+        this.leader = team.getUser().getName();
+        this.oneLine = team.getOneLine();
+        this.description = team.getDescription();
+        this.university = team.getUniversity();
+        this.link = team.getLink();
+        this.requirementList = team.getRequirementList().stream().map(RequirementDto::new).collect(toList());
+    }
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/UserDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/UserDto.java
@@ -1,0 +1,34 @@
+package com.springmvc.unid.controller.dto;
+
+import com.springmvc.unid.domain.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * UserDto의 용도
+ * 1. 회원가입 Request/Response
+ * 2. 로그인 성공 시 서버가 클라이언트에게 보내는 Response
+ * 3. 회원정보 수정 Request/Response
+ * 4. user 조회 결과 Response
+ * 5. user가 받은 알림 조회를 위해 클라이언트가 서버에게 보내는 Request
+ */
+@Data
+@NoArgsConstructor
+public class UserDto {
+
+    private Long userId;
+    private String loginId;
+    private String name;
+    private String university;
+    private String major;
+    private String link;
+
+    public UserDto(User user) {
+        this.userId = user.getId();
+        this.loginId = user.getLoginId();
+        this.name = user.getName();
+        this.university = user.getUniversity();
+        this.major = user.getMajor();
+        this.link = user.getLink();
+    }
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateNotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateNotifyDto.java
@@ -1,0 +1,14 @@
+package com.springmvc.unid.controller.dto.request;
+
+import com.springmvc.unid.controller.dto.response.NotifyDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class RequestCreateNotifyDto { // 알림 생성 요청
+    private List<Long> receiverIds;
+    private NotifyDto notifyDto;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateTeamDto.java
@@ -1,0 +1,19 @@
+package com.springmvc.unid.controller.dto.request;
+
+import com.springmvc.unid.controller.dto.RequirementDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class RequestCreateTeamDto { // 팀 생성 요청
+    private String name;
+    private String user;
+    private String oneLine;
+    private String description;
+    private String university;
+    private String link;
+    private List<RequirementDto> requirementList;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateUserDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestCreateUserDto.java
@@ -1,0 +1,16 @@
+package com.springmvc.unid.controller.dto.request;
+
+import com.springmvc.unid.domain.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestCreateUserDto { // 회원가입 요청
+    private String loginId;
+    private String pw;
+    private String name;
+    private String university;
+    private String major;
+    private String link;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteNotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteNotifyDto.java
@@ -1,0 +1,10 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestDeleteNotifyDto {
+    private Long notifyId; // 알림의 id
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteRequirementDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestDeleteRequirementDto.java
@@ -1,0 +1,11 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestDeleteRequirementDto { // 팀 요구사항 삭제 요청
+    private Long requirementId;
+    private Long userId;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestExitTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestExitTeamDto.java
@@ -1,0 +1,10 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestExitTeamDto { // 팀 탈퇴 요청
+    private Long teamId;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestJoinTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestJoinTeamDto.java
@@ -1,0 +1,10 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestJoinTeamDto { // 팀 가입 요청
+    private Long teamId;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestLoginDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestLoginDto.java
@@ -1,0 +1,11 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestLoginDto { // 로그인 요청
+    private String loginId;
+    private String pw;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUnivMemberDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUnivMemberDto.java
@@ -1,0 +1,10 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestUnivMemberDto { // 대학 내 팀 조회 등을 위한 대학명 요청
+    private String university;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamDto.java
@@ -1,0 +1,12 @@
+package com.springmvc.unid.controller.dto.request;
+
+import com.springmvc.unid.controller.dto.TeamDto;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestUpdateTeamDto { // 팀 정보 수정 요청
+    private TeamDto teamDto;
+    private Long userId;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamLeaderDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/request/RequestUpdateTeamLeaderDto.java
@@ -1,0 +1,11 @@
+package com.springmvc.unid.controller.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RequestUpdateTeamLeaderDto { // 팀장 변경 요청
+    private Long leaderId;
+    private Long nextId;
+}

--- a/src/main/java/com/springmvc/unid/controller/dto/response/NotifyDto.java
+++ b/src/main/java/com/springmvc/unid/controller/dto/response/NotifyDto.java
@@ -1,0 +1,30 @@
+package com.springmvc.unid.controller.dto.response;
+
+import com.springmvc.unid.domain.Notify;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * ResponseNotifyDto의 용도
+ * 알림 조회 결과 객체 (response)
+ */
+@Data
+@NoArgsConstructor
+public class NotifyDto {
+
+        private Long notifyId; // 알림의 id
+        private Long type; // 알림의 종류
+        private String sender; // 알림의 발신자
+        private String teamName; // 알림의 발신자가 소속된 팀 이름
+        private String contents; // 알림의 내용
+        private String link; // 알림의 첨부 링크
+
+        public NotifyDto(Notify notify) {
+                this.notifyId = notify.getId();
+                this.type = notify.getType();
+                this.sender = notify.getUser().getName();
+                this.teamName = notify.getTeam().getName();
+                this.contents = notify.getContents();
+                this.link = notify.getLink();
+        }
+}

--- a/src/main/java/com/springmvc/unid/domain/Notify.java
+++ b/src/main/java/com/springmvc/unid/domain/Notify.java
@@ -1,0 +1,52 @@
+package com.springmvc.unid.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter @Setter
+@Table(name = "notify")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notify {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notify_id")
+    private Long id;
+
+    private Long type; // 알림의 종류
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; // 발신자의 id
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team; // 발신자가 지원한(소속된) 팀
+
+    private String contents; // 알림(지원서, 가입승인, 가입거절, 탈퇴, 종료) 내용
+
+    private String link; // 지원자(승인한 팀장)이 첨부한 링크
+
+    @JsonIgnore // 클라이언트가 접근할 필요가 없는 정보
+    @OneToMany(mappedBy = "notify")
+    private List<UserNotify> userNotifies = new ArrayList<>(); // 이 알림을 수신한 사용자 명단
+
+    // 생성 메서드
+    public static Notify createNotify(Long type, User user, Team team, String contents, String link) {
+        Notify notify = new Notify();
+        notify.setType(type);
+        notify.setUser(user);
+        notify.setTeam(team);
+        notify.setContents(contents);
+        notify.setLink(link);
+        return notify;
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/domain/Requirement.java
+++ b/src/main/java/com/springmvc/unid/domain/Requirement.java
@@ -1,0 +1,40 @@
+package com.springmvc.unid.domain;
+
+import com.springmvc.unid.controller.dto.RequirementDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Setter @Getter
+@Table(name = "requirement")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Requirement {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "requirement_id")
+    private Long id;
+
+    private String position; // 구인 파트
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team; // Team과의 다대일 관계
+
+    private Long n; // 구인 파트별 팀원 수
+
+    private String requireContents; // 구체적인 구인 요구사항
+
+    // 생성 메서드
+    public static Requirement createRequirement(RequirementDto requirementDto) {
+        Requirement requirement = new Requirement();
+        requirement.setPosition(requirementDto.getPosition());
+        requirement.setN(requirementDto.getN());
+        requirement.setRequireContents(requirementDto.getRequireContents());
+        return requirement;
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/domain/Team.java
+++ b/src/main/java/com/springmvc/unid/domain/Team.java
@@ -1,0 +1,105 @@
+package com.springmvc.unid.domain;
+
+import com.springmvc.unid.controller.dto.RequirementDto;
+import com.springmvc.unid.controller.dto.TeamDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "team")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+
+    private String name; // 팀 이름
+
+    // 각 팀 테이블은 팀장의 id를 외래키로 가짐
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; // 팀장
+
+    private String oneLine; // 팀의 한줄설명
+
+    private String description; // 팀의 구체적 설명
+
+    private String university; // 팀의 소속 대학
+
+    private String link; // 팀의 링크
+
+    @OneToMany(mappedBy = "team")
+    private List<Requirement> requirementList = new ArrayList<>(); // 팀원 모집 요구사항
+
+    @OneToMany(mappedBy = "team")
+    private List<TeamMember> teamMembersList = new ArrayList<>(); // 소속된 팀원 명단
+
+    // 생성 메서드
+    public static Team createTeam(String name, User user, String oneLine, String description, String university, String link) {
+        Team team = new Team();
+        team.setName(name);
+        team.setUser(user);
+        team.setOneLine(oneLine);
+        team.setDescription(description);
+        team.setUniversity(university);
+        team.setLink(link);
+        return team;
+    }
+
+    public void updateTeam(TeamDto teamDto) {
+        this.name = teamDto.getName();
+        this.oneLine = teamDto.getOneLine();
+        this.description = teamDto.getDescription();
+        this.university = teamDto.getUniversity();
+        this.link = teamDto.getLink();
+    } // 팀 정보 수정
+
+    // 비즈니스 로직
+    public void addRequirement(Requirement requirement) {
+        requirement.setTeam(this);
+        this.requirementList.add(requirement);
+    } // 팀원 모집 요구사항 추가
+
+    public void deleteRequirement(Long id) {
+        for(Requirement requirement : this.requirementList) {
+            if(Objects.equals(requirement.getId(), id)) {
+                this.requirementList.remove(requirement);
+                break;
+            }
+        }
+    } // 팀원 모집 요구사항 삭제
+
+    public void modifyRequirement(Long id, RequirementDto requirementDto) {
+        for(Requirement requirement : this.requirementList) {
+            if (id.equals(requirement.getId())) {
+                requirement.setPosition(requirementDto.getPosition());
+                requirement.setN(requirementDto.getN());
+                requirement.setRequireContents(requirementDto.getRequireContents());
+                break;
+            }
+        }
+    } // 팀원 모집 요구사항 수정
+
+    public Requirement getOneRequirement(Long id){
+        for(Requirement requirement : this.requirementList) {
+            if(Objects.equals(requirement.getId(), id)) {
+                return requirement;
+            }
+        }
+        return null;
+    } // 특정 요구사항 가져오기
+
+    public void setTeamLeader(User user) {
+        this.user = user;
+    } // 팀장 교체
+}

--- a/src/main/java/com/springmvc/unid/domain/TeamMember.java
+++ b/src/main/java/com/springmvc/unid/domain/TeamMember.java
@@ -1,0 +1,39 @@
+package com.springmvc.unid.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Setter @Getter
+@Table(name = "team_member")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamMember { // Team과 User의 다대다 관계로 인해 생성된 테이블
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_member_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user; // 사용자 id - 외래키
+
+    private LocalDate joinDate; // 팀 가입일
+
+    // 생성 메서드
+    public static TeamMember createTeamMember(Team team, User user, LocalDate joinDate) {
+        TeamMember teamMember = new TeamMember();
+        teamMember.setTeam(team);
+        teamMember.setUser(user);
+        teamMember.setJoinDate(joinDate);
+        return teamMember;
+    }
+}

--- a/src/main/java/com/springmvc/unid/domain/User.java
+++ b/src/main/java/com/springmvc/unid/domain/User.java
@@ -1,0 +1,77 @@
+package com.springmvc.unid.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.springmvc.unid.controller.dto.request.RequestCreateUserDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) // DB가 알아서 값을 생성
+    @Column(name = "user_id")
+    private Long id;
+
+    private String loginId; // 사용자 id
+
+    private String name; // 사용자 별명
+
+    @JsonIgnore
+    private String pw; // 사용자 비밀번호
+
+    private String university; // 사용자 소속 대학
+
+    private String major; // 사용자의 소속 학과
+
+    private String link; // 사용자의 링크
+
+    @OneToMany(mappedBy = "user")
+    private List<UserNotify> userNotifyList = new ArrayList<>(); // 사용자가 가지고 있는 알림 명단
+
+    @OneToMany(mappedBy = "user")
+    private List<TeamMember> teamMemberList = new ArrayList<>(); // 사용자가 소속된 팀 명단
+
+    // 생성 메서드 (테스트코드용)
+    public static User createUser(String LoginId, String name, String pw, String university, String major, String link) {
+        User user = new User();
+        user.setLoginId(LoginId);
+        user.setName(name);
+        user.setPw(pw);
+        user.setUniversity(university);
+        user.setMajor(major);
+        user.setLink(link);
+        return user;
+    }
+
+    // 생성 메서드(컨트롤러 회원가입용)
+    public static User createUser(RequestCreateUserDto requestCreateUserDto) {
+        User user = new User();
+        user.setLoginId(requestCreateUserDto.getLoginId());
+        user.setName(requestCreateUserDto.getName());
+        user.setPw(requestCreateUserDto.getPw());
+        user.setUniversity(requestCreateUserDto.getUniversity());
+        user.setMajor(requestCreateUserDto.getMajor());
+        user.setLink(requestCreateUserDto.getLink());
+        return user;
+    }
+
+    // 비즈니스 로직
+    // 사용자 정보 수정
+    public void update(String name, String university, String major, String link) {
+        this.name = name;
+        this.university = university;
+        this.major = major;
+        this.link = link;
+    }
+}
+

--- a/src/main/java/com/springmvc/unid/domain/UserNotify.java
+++ b/src/main/java/com/springmvc/unid/domain/UserNotify.java
@@ -1,0 +1,39 @@
+package com.springmvc.unid.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Setter @Getter
+@Table(name = "user_notify")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotify { // User와 Notify의 다대다 관계로 인해 생성된 테이블
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_notify_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user; // 수신자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notify_id")
+    private Notify notify; // 알림
+
+    private LocalDate notifyDate; // 알림 수신 시간
+
+    // 생성 메서드
+    public static UserNotify createUserNotify(User user, Notify notify, LocalDate notifyDate) {
+        UserNotify userNotify = new UserNotify();
+        userNotify.setUser(user);
+        userNotify.setNotify(notify);
+        userNotify.setNotifyDate(notifyDate);
+        return userNotify;
+    }
+}

--- a/src/main/java/com/springmvc/unid/repository/NotifyRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/NotifyRepository.java
@@ -1,0 +1,23 @@
+package com.springmvc.unid.repository;
+
+import com.springmvc.unid.domain.Notify;
+import com.springmvc.unid.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NotifyRepository extends JpaRepository<Notify, Long> {
+    // 알림 생성 -> save(Notify notify)
+
+    // 알림 조회
+    Optional<Notify> findById(Long Id);
+
+    // user가 보낸 알림 조회
+    List<Notify> findByUser(User user);
+
+    // 알림 삭제
+    void deleteById(Long Id);
+}

--- a/src/main/java/com/springmvc/unid/repository/TeamMemberRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/TeamMemberRepository.java
@@ -1,0 +1,24 @@
+package com.springmvc.unid.repository;
+
+import com.springmvc.unid.domain.Team;
+import com.springmvc.unid.domain.TeamMember;
+import com.springmvc.unid.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    // 특정 user의 소속 팀 조회
+    List<TeamMember> findByUser(User user);
+
+    // 특정 팀의 소속 user 조회
+    List<TeamMember> findByTeam(Team team);
+
+    // user가 팀에 가입 - save
+
+    // user가 팀에서 탈퇴
+    void delete(TeamMember teamMember);
+}

--- a/src/main/java/com/springmvc/unid/repository/TeamRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/TeamRepository.java
@@ -1,0 +1,28 @@
+package com.springmvc.unid.repository;
+
+import com.springmvc.unid.domain.Team;
+import com.springmvc.unid.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    // 팀 생성 및 수정 -> save(Team team)
+
+    // 팀 조회
+    Optional<Team> findById(Long id);
+
+    // 팀 삭제
+    void deleteById(Long id);
+
+    // 특정 대학 소속 팀 조회
+    List<Team> findByUniversity(String university);
+
+    // 특정 팀장이 이끄는 팀들 조회
+    List<Team> findByUser(User user);
+
+    Optional<Team> findByName(String teamName);
+}

--- a/src/main/java/com/springmvc/unid/repository/UserNotifyRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/UserNotifyRepository.java
@@ -1,0 +1,27 @@
+package com.springmvc.unid.repository;
+
+import com.springmvc.unid.domain.Notify;
+import com.springmvc.unid.domain.User;
+import com.springmvc.unid.domain.UserNotify;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserNotifyRepository extends JpaRepository<UserNotify, Long> {
+
+    // 알림을 받은 user 조회
+    List<UserNotify> findByNotify(Notify notify);
+
+    // user가 받은 알림 조회
+    List<UserNotify> findByUser(User user);
+
+    // 특정 user에게 특정 알림 전송 - save(UserNotify userNotify);
+
+    // user가 알림 삭제 - deleteById(Long id);
+
+    // 특정 유저가 알림을 이미 받았는지 확인하기 위한 조회
+    Optional<UserNotify> findByUserAndNotify(User user, Notify notify);
+}

--- a/src/main/java/com/springmvc/unid/repository/UserRepository.java
+++ b/src/main/java/com/springmvc/unid/repository/UserRepository.java
@@ -1,0 +1,31 @@
+package com.springmvc.unid.repository;
+
+import com.springmvc.unid.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 회원 가입 및 정보 수정 - save(User user)
+
+    // id로 회원 조회
+    Optional<User> findById(Long Id);
+
+    // name으로 회원 조회
+    Optional<User> findByName(String name);
+
+    // LoginId로 회원 조회
+    Optional<User> findByLoginId(String loginId);
+
+    // 회원 탈퇴
+    void deleteById(Long id);
+
+    // 회원 로그인에 필요
+    Optional<User> findByLoginIdAndPw(String loginId, String pw);
+
+    // 대학으로 회원 조회
+    List<User> findByUniversity(String university);
+}

--- a/src/main/java/com/springmvc/unid/service/NotifyService.java
+++ b/src/main/java/com/springmvc/unid/service/NotifyService.java
@@ -1,0 +1,98 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.controller.dto.UserDto;
+import com.springmvc.unid.controller.dto.response.NotifyDto;
+import com.springmvc.unid.domain.Notify;
+import com.springmvc.unid.domain.Team;
+import com.springmvc.unid.domain.User;
+import com.springmvc.unid.domain.UserNotify;
+import com.springmvc.unid.repository.NotifyRepository;
+import com.springmvc.unid.repository.TeamRepository;
+import com.springmvc.unid.repository.UserNotifyRepository;
+import com.springmvc.unid.repository.UserRepository;
+import com.springmvc.unid.util.exception.CustomException;
+import com.springmvc.unid.util.exception.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NotifyService {
+
+    private final NotifyRepository notifyRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+    private final UserNotifyRepository userNotifyRepository;
+
+    // 알림 생성 (및 전송)
+    @Transactional
+    public Long create(List<Long> receivedId, NotifyDto notifyDto){
+        User user = userRepository.findByName(notifyDto.getSender()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        Team team = teamRepository.findByName(notifyDto.getTeamName()).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        Notify notify = Notify.createNotify(notifyDto.getType(), user, team, notifyDto.getContents(), notifyDto.getLink());
+        notifyRepository.save(notify);
+
+        for(Long id : receivedId){
+            User receivedUser = userRepository.findById(id).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+            userNotifyRepository.save(UserNotify.createUserNotify(receivedUser, notify, LocalDate.now()));
+        }
+        return notify.getId();
+    }
+
+    // user가 받은 알림 삭제
+    @Transactional
+    public void deleteNotify(Long userId, Long notifyId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        Notify notify = notifyRepository.findById(notifyId).orElseThrow(() -> new CustomException(ResponseCode.NOTIFY_NOT_FOUND));
+        UserNotify userNotify = userNotifyRepository.findByUserAndNotify(user, notify).orElseThrow(() -> new CustomException(ResponseCode.NOTIFY_NOT_FOUND));
+        userNotifyRepository.delete(userNotify);
+    }
+
+    // 특정 user가 받은 모든 알림 조회
+    public List<NotifyDto> findAllByUser(UserDto userDto){
+        User user = userRepository.findById(userDto.getUserId()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        List<UserNotify> userNotifies = userNotifyRepository.findByUser(user);
+        List<NotifyDto> notifies = new ArrayList<>();
+        for(UserNotify userNotify : userNotifies){
+            notifies.add(new NotifyDto(userNotify.getNotify()));
+        }
+        return notifies;
+    }
+
+    // 특정 user가 보낸 모든 알림 조회
+    public List<NotifyDto> findAllBySender(UserDto userDto){
+        User user = userRepository.findById(userDto.getUserId()).orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+        List<Notify> notifies = notifyRepository.findByUser(user);
+        List<NotifyDto> notifyDtos = new ArrayList<>();
+        for(Notify notify : notifies){
+            notifyDtos.add(new NotifyDto(notify));
+        }
+        return notifyDtos;
+    }
+
+    // user에게 알림을 전송
+    @Transactional
+    public void sendNotify(User user, Notify notify){
+        UserNotify userNotify = UserNotify.createUserNotify(user, notify, LocalDate.now());
+        userNotify.setUser(user);
+        userNotify.setNotify(notify);
+        userNotifyRepository.save(userNotify);
+    }
+
+    // 전체 알림 조회
+    public List<NotifyDto> findAll(){
+        List<Notify> notifies = notifyRepository.findAll();
+        List<NotifyDto> notifyDtos = new ArrayList<>();
+        for(Notify notify : notifies){
+            notifyDtos.add(new NotifyDto(notify));
+        }
+        return notifyDtos;
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/service/TeamService.java
+++ b/src/main/java/com/springmvc/unid/service/TeamService.java
@@ -1,0 +1,214 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.controller.dto.RequirementDto;
+import com.springmvc.unid.controller.dto.TeamDto;
+import com.springmvc.unid.controller.dto.UserDto;
+import com.springmvc.unid.controller.dto.request.RequestCreateTeamDto;
+import com.springmvc.unid.domain.Requirement;
+import com.springmvc.unid.domain.Team;
+import com.springmvc.unid.domain.User;
+import com.springmvc.unid.domain.TeamMember;
+import com.springmvc.unid.repository.UserRepository;
+import com.springmvc.unid.util.exception.CustomException;
+import com.springmvc.unid.util.exception.ResponseCode;
+import com.springmvc.unid.repository.TeamMemberRepository;
+import com.springmvc.unid.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    public TeamDto findOne(Long id) {
+        Team team = teamRepository.findById(id).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        return new TeamDto(team);
+    }
+
+    public List<TeamDto> findAll() {
+        List<Team> teams = teamRepository.findAll();
+        List<TeamDto> teamDtos = new ArrayList<>();
+        for (Team team : teams) {
+            teamDtos.add(new TeamDto(team));
+        }
+        return teamDtos;
+    }
+
+    // user가 현재 소속된 팀 조회
+    public List<TeamDto> findTeamByUser(UserDto userDto) {
+        // List<TeamMember> TeamMembers = user.getTeamMemberList(); // 위와 아래의 차이 공부하기
+        User user = userRepository.findByName(userDto.getName()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        List<TeamMember> TeamMembers = teamMemberRepository.findByUser(user);
+        List<TeamDto> teams = new ArrayList<>();
+        for (TeamMember teamMember : TeamMembers) {
+            teams.add(new TeamDto(teamMember.getTeam()));
+        }
+        return teams;
+    }
+
+    // user가 팀장인 팀 조회
+    public List<TeamDto> findTeamByLeader(UserDto userDto) {
+        List<Team> teams = teamRepository.findByUser(userRepository.findByName(userDto.getName()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND)));
+        List<TeamDto> teamsDtos = new ArrayList<>();
+        for (Team team : teams) {
+            teamsDtos.add(new TeamDto(team));
+        }
+        return teamsDtos;
+    }
+
+    // user의 대학 소속 팀 조회
+    public List<TeamDto> findTeamByUniv(String university) {
+        List<Team> teams= teamRepository.findByUniversity(university);
+        List<TeamDto> teamsDtos = new ArrayList<>();
+        for (Team team : teams) {
+            teamsDtos.add(new TeamDto(team));
+        }
+        return teamsDtos;
+    }
+
+    // 팀 생성
+    @Transactional
+    public Long createTeam(RequestCreateTeamDto teamDto) {
+        Team team = Team.createTeam(teamDto.getName(), userRepository.findByName(teamDto.getUser()).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND)),
+                teamDto.getOneLine(), teamDto.getDescription(), teamDto.getLink(), teamDto.getUniversity());
+        ValidateDuplicateTeam(team);
+        team.setTeamLeader(team.getUser());
+        teamRepository.save(team);
+        teamMemberRepository.save(TeamMember.createTeamMember(team, team.getUser(), LocalDate.now()));
+        return team.getId();
+    }
+
+    // 중복 팀명 검증
+    public void ValidateDuplicateTeam(Team team) {
+        Optional<Team> findTeam = teamRepository.findByName(team.getName());
+        if (findTeam.isPresent()) {
+            throw new CustomException(ResponseCode.DUPLICATED_TEAM);
+        }
+    }
+
+    // 팀 정보 수정 (팀장만 가능)
+    @Transactional
+    public Long update(Long id, TeamDto teamDto, Long userId) {
+        Team findTeam = teamRepository.findById(id).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if(!findTeam.getUser().getId().equals(userId)) throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        findTeam.updateTeam(teamDto);
+        teamRepository.save(findTeam);
+        return findTeam.getId();
+    }
+
+    // 팀 삭제 (팀장만 가능)
+    @Transactional
+    public void deleteTeam(Long teamId, Long leaderId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if(!team.getUser().getId().equals(leaderId)) throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        teamRepository.delete(team);
+    }
+
+    // 특정 팀의 팀원 조회
+    public List<UserDto> findTeamMember(Long teamId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        List<TeamMember> teamMembers = teamMemberRepository.findByTeam(team);
+        List<UserDto> userDtos = new ArrayList<>();
+        for (TeamMember teamMember : teamMembers) {
+            userDtos.add(new UserDto(teamMember.getUser()));
+        }
+        return userDtos;
+    }
+
+    // 특정 팀의 팀장 조회
+    public UserDto findTeamLeader(Long teamId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        return new UserDto(team.getUser());
+    }
+
+    // 팀에 특정 팀원 가입
+    @Transactional
+    public void joinTeam(Long userId, Long teamId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        ValidateDuplicateTeamMember(user, team);
+        TeamMember teamMember = TeamMember.createTeamMember(team, user, LocalDate.now());
+        teamMemberRepository.save(teamMember);
+    }
+
+    // 이미 팀에 가입되어 있는 팀원인지 검증
+    public void ValidateDuplicateTeamMember(User user, Team team) {
+        List<TeamMember> findTeamMembers = teamMemberRepository.findByUser(user);
+        for (TeamMember teamMember : findTeamMembers) {
+            if (teamMember.getTeam().equals(team)) {
+                throw new CustomException(ResponseCode.DUPLICATED_TEAM_MEMBER);
+            }
+        }
+    }
+
+    // 팀에 특정 팀원 탈퇴 (팀장은 탈퇴 불가능)
+    @Transactional
+    public void leaveTeam(Long userId, Long teamId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if(team.getUser().equals(user)) throw new CustomException(ResponseCode.TEAM_LEADER_CANNOT_LEAVE);
+        List<TeamMember> findTeamMembers = teamMemberRepository.findByUser(user);
+        for (TeamMember teamMember : findTeamMembers) {
+            if (teamMember.getTeam().equals(team)) {
+                teamMemberRepository.delete(teamMember);
+            }
+        }
+    }
+
+    // 특정 팀의 팀장 변경 (팀장만 가능)
+    @Transactional
+    public void setTeamLeader(Long leaderId, Long nextId, Long teamId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if(!team.getUser().getId().equals(leaderId)) throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        User nextLeader = userRepository.findById(nextId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        team.setUser(nextLeader);
+        teamRepository.save(team);
+    }
+
+    // 특정 팀의 구인 요구사항 추가 (팀장만 가능)
+    @Transactional
+    public Long addRequirement(Long leaderId, RequirementDto requirementDto) {
+        Requirement requirement = Requirement.createRequirement(requirementDto);
+        Team team = requirement.getTeam();
+        if (!team.getUser().getId().equals(leaderId)) {
+            throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        }
+        team.addRequirement(requirement);
+        teamRepository.save(team);
+        return requirement.getId();
+    }
+
+    // 특정 팀의 구인 요구사항 수정 (팀장만 가능)
+    @Transactional
+    public void updateRequirement(Long leaderId, Long reqId, RequirementDto requirementDto) {
+        Team team = teamRepository.findById(requirementDto.getTeamId()).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if (!team.getUser().getId().equals(leaderId)) {
+            throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        }
+        team.modifyRequirement(reqId, requirementDto);
+        teamRepository.save(team);
+    }
+
+    // 특정 팀의 구인 요구사항 제거 (팀장만 가능)
+    @Transactional
+    public void deleteRequirement(Long teamId, Long requirementId, Long userId) {
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new CustomException(ResponseCode.TEAM_NOT_FOUND));
+        if (!team.getUser().getId().equals(userId)) {
+            throw new CustomException(ResponseCode.NOT_TEAM_LEADER);
+        }
+        team.deleteRequirement(requirementId);
+        teamRepository.save(team);
+    }
+
+}

--- a/src/main/java/com/springmvc/unid/service/UserService.java
+++ b/src/main/java/com/springmvc/unid/service/UserService.java
@@ -1,0 +1,117 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.controller.dto.TeamDto;
+import com.springmvc.unid.controller.dto.UserDto;
+import com.springmvc.unid.controller.dto.request.RequestCreateUserDto;
+import com.springmvc.unid.domain.*;
+import com.springmvc.unid.util.exception.CustomException;
+import com.springmvc.unid.util.exception.ResponseCode;
+import com.springmvc.unid.repository.TeamMemberRepository;
+import com.springmvc.unid.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    // 로그인
+    public Long login(String id, String password) {
+        Optional<User> findUsers = userRepository.findByLoginIdAndPw(id, password);
+        if (findUsers.isPresent()) {
+            if (findUsers.get().getPw().equals(password)) {
+                return findUsers.get().getId();
+            } else {
+                throw new CustomException(ResponseCode.USER_LOGIN_FAILED);
+            }
+        } else {
+            throw new CustomException(ResponseCode.USER_NOT_FOUND);
+        }
+    }
+
+    // user 가입
+    @Transactional
+    public Long join(RequestCreateUserDto userDto) {
+        User user = User.createUser(userDto);
+        validateDuplicateUser(user);
+        userRepository.save(user);
+        return user.getId();
+    }
+
+    // 중복 user 검증
+    private void validateDuplicateUser(User user) {
+        Optional<User> findUserByLoginId = userRepository.findByLoginId(user.getLoginId());
+        Optional<User> findUserByName = userRepository.findByName(user.getName());
+        if (findUserByName.isPresent() || findUserByLoginId.isPresent()) {
+            throw new CustomException(ResponseCode.DUPLICATED_USER);
+        }
+    }
+
+    // user 탈퇴
+    @Transactional
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    // user 정보 수정
+    @Transactional
+    public void update(Long id, String newName, String newUniv, String newMajor, String newLink) {
+        User findUser = userRepository.findById(id).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND));
+        findUser.update(newName, newUniv, newMajor, newLink);
+        userRepository.save(findUser);
+    }
+
+    // 전체 user 조회
+    public List<UserDto> findUsers() {
+        List<User> users = userRepository.findAll();
+        List<UserDto> userDtos = new ArrayList<>();
+        for (User user : users) {
+            userDtos.add(new UserDto(user));
+        }
+        return userDtos;
+    }
+
+    // 특정 user 조회
+    public UserDto findOne(Long userId) {
+        return new UserDto(userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND)));
+    }
+
+    // 특정 user가 소속된 팀 조회
+    public List<TeamDto> findTeamsByUserId(Long userId) {
+        List<TeamMember> teams = teamMemberRepository.findByUser(userRepository.findById(userId).orElseThrow(() -> new CustomException(ResponseCode.USER_NOT_FOUND)));
+        List<TeamDto> teamDtos = new ArrayList<>();
+        for (TeamMember team : teams) {
+            teamDtos.add(new TeamDto(team.getTeam()));
+        }
+        return teamDtos;
+    }
+
+    /*// 특정 알림을 받은 user 조회
+    public List<User> findUsersByUserNotify(Notify notify) {
+        List<User> users = new ArrayList<>();
+        List<UserNotify> userNotifies = userNotifyRepository.findByNotify(notify);
+        for (UserNotify userNotify : userNotifies) {
+            users.add(userNotify.getUser());
+        }
+        return users;
+    } */
+
+    /*// 특정 대학에 소속된 user 조회
+    public List<UserDto> findUsersByUniversity(String university) {
+        List<User> users = userRepository.findByUniversity(university);
+        List<UserDto> userDtos = new ArrayList<>();
+        for (User user : users) {
+            userDtos.add(new UserDto(user));
+        }
+        return userDtos;
+    }*/
+}

--- a/src/main/java/com/springmvc/unid/util/api/ApiBody.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiBody.java
@@ -1,0 +1,19 @@
+package com.springmvc.unid.util.api;
+
+public class ApiBody<T> {
+    private final T data;
+    private final T msg;
+
+    public ApiBody(T data, T msg) {
+        this.data = data;
+        this.msg = msg;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public T getMsg() {
+        return msg;
+    }
+}

--- a/src/main/java/com/springmvc/unid/util/api/ApiHeader.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiHeader.java
@@ -1,0 +1,19 @@
+package com.springmvc.unid.util.api;
+
+public class ApiHeader {
+    private final int resultCode;
+    private final String codeName;
+
+    public ApiHeader(int resultCode, String codeName) {
+        this.resultCode = resultCode;
+        this.codeName = codeName;
+    }
+
+    public int getResultCode() {
+        return resultCode;
+    }
+
+    public String getCodeName() {
+        return codeName;
+    }
+}

--- a/src/main/java/com/springmvc/unid/util/api/ApiResponse.java
+++ b/src/main/java/com/springmvc/unid/util/api/ApiResponse.java
@@ -1,0 +1,33 @@
+package com.springmvc.unid.util.api;
+
+
+import com.springmvc.unid.util.exception.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiResponse<T> {
+
+    private ApiHeader header;
+    private ApiBody body;
+
+    private static final int SUCCESS = 200;
+
+    public ApiResponse(ApiHeader header, ApiBody body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public ApiResponse(ApiHeader header){
+        this.header = header;
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message){
+        return new ApiResponse<T>(new ApiHeader(SUCCESS, "SUCCESS"), new ApiBody(data, message));
+    }
+
+    public static <T> ApiResponse<T> fail(ResponseCode responseCode){
+        return new ApiResponse(new ApiHeader(responseCode.getHttpStatusCode(), responseCode.getMessage()), new ApiBody(null, responseCode.getMessage()));
+    }
+}

--- a/src/main/java/com/springmvc/unid/util/exception/CustomException.java
+++ b/src/main/java/com/springmvc/unid/util/exception/CustomException.java
@@ -1,0 +1,12 @@
+package com.springmvc.unid.util.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CustomException extends RuntimeException {
+    private final ResponseCode responseCode;
+}
+
+

--- a/src/main/java/com/springmvc/unid/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/springmvc/unid/util/exception/GlobalExceptionHandler.java
@@ -1,0 +1,12 @@
+package com.springmvc.unid.util.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+
+
+}

--- a/src/main/java/com/springmvc/unid/util/exception/ResponseCode.java
+++ b/src/main/java/com/springmvc/unid/util/exception/ResponseCode.java
@@ -1,0 +1,85 @@
+package com.springmvc.unid.util.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor(access =  AccessLevel.PRIVATE)
+@Getter
+public enum ResponseCode {
+
+        /**
+         * 400 Bad Request
+         */
+        BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
+        NOT_TEAM_LEADER(HttpStatus.BAD_REQUEST, false,"팀장이 아닙니다."),
+        USER_LOGIN_FAILED(HttpStatus.BAD_REQUEST, false,"로그인에 실패했습니다."),
+        TEAM_LEADER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, false,"팀장은 팀에서 탈퇴할 수 없습니다."),
+
+        /**
+         * 404 NOT FOUND
+         */
+        USER_NOT_FOUND(HttpStatus.NOT_FOUND, false,"User Not Found"),
+        TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, false,"Team Not Found"),
+        NOTIFY_NOT_FOUND(HttpStatus.NOT_FOUND, false,"Notify Not Found"),
+        REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, false,"Requirement Not Found"),
+
+        /**
+         * 409 CONFLICT
+         */
+        DUPLICATED_USER(HttpStatus.CONFLICT, false,"Duplicated User"),
+        DUPLICATED_TEAM(HttpStatus.CONFLICT, false, "Duplicated Team"),
+        DUPLICATED_NOTIFY(HttpStatus.CONFLICT, false, "Duplicated Notify"),
+        DUPLICATED_TEAM_MEMBER(HttpStatus.CONFLICT, false, "Duplicated Team Member"),
+
+        /**
+         * 500 INTERNAL SERVER ERROR
+         */
+        INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false,"Server Error"),
+
+        /**
+         * 200 OK
+         */
+        SIGNIN_SUCCESS(HttpStatus.OK, true, "로그인 성공"),
+        USER_READ_SUCCESS(HttpStatus.OK, true, "유저 조회 성공"),
+        TEAM_READ_SUCCESS(HttpStatus.OK, true, "팀 조회 성공"),
+        TEAM_JOIN_SUCCESS(HttpStatus.OK, true, "팀 가입 성공"),
+        TEAM_MEMBER_READ_SUCCESS(HttpStatus.OK, true, "팀원 조회 성공"),
+        REQUIREMENT_READ_SUCCESS(HttpStatus.OK, true, "요구사항 조회 성공"),
+
+        NOTIFY_READ_SUCCESS(HttpStatus.OK, true, "알림 조회 성공"),
+        NOTIFY_SEND_SUCCESS(HttpStatus.OK, true, "알림 전송 성공"),
+
+        USER_DELETE_SUCCESS(HttpStatus.OK, true, "유저 탈퇴 성공"),
+        TEAM_DELETE_SUCCESS(HttpStatus.OK, true, "팀 삭제 성공"),
+        TEAM_LEAVE_SUCCESS(HttpStatus.OK, true, "팀 탈퇴 성공"),
+        REQUIREMENT_DELETE_SUCCESS(HttpStatus.OK, true, "요구사항 삭제 성공"),
+        NOTIFY_DELETE_SUCCESS(HttpStatus.OK, true, "알림 삭제 성공"),
+
+        USER_UPDATE_SUCCESS(HttpStatus.OK, true, "유저 정보 수정 성공"),
+        TEAM_UPDATE_SUCCESS(HttpStatus.OK, true, "팀 정보 수정 성공"),
+        REQUIREMENT_UPDATE_SUCCESS(HttpStatus.OK, true, "요구사항 정보 수정 성공"),
+
+
+        /**
+         *  201 Created
+         */
+        SIGNUP_SUCCESS(HttpStatus.CREATED, true, "회원가입 성공"),
+        TEAM_CREATE_SUCCESS(HttpStatus.CREATED, true, "팀 생성 성공"),
+        NOTIFY_CREATE_SUCCESS(HttpStatus.CREATED, true, "알림 생성 성공"),
+        REQUIREMENT_CREATE_SUCCESS(HttpStatus.CREATED, true, "요구사항 생성 성공"),
+
+        /**
+         * 204 No Content
+         */
+        LIST_EMPTY(HttpStatus.NO_CONTENT, true, "리스트가 비어있습니다.");
+
+        private final HttpStatus httpStatus;
+        private final Boolean success;
+        private final String message;
+
+        public int getHttpStatusCode() {
+            return httpStatus.value();
+        }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.profiles.include = mysql

--- a/src/test/java/com/springmvc/unid/service/NotifyServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/NotifyServiceTest.java
@@ -1,0 +1,137 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.domain.*;
+import com.springmvc.unid.repository.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class NotifyServiceTest {
+
+    @Autowired NotifyService notifyService;
+    @Autowired NotifyRepository notifyRepository;
+    @Autowired UserNotifyRepository userNotifyRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired TeamRepository teamRepository;
+    @Autowired TeamMemberRepository teamMemberRepository;
+
+    @Test
+    public void 알림생성() throws Exception {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        TeamMember teamMember1 = TeamMember.createTeamMember(team, user1, LocalDate.now());
+        teamMemberRepository.save(teamMember1);
+
+        Notify notify = Notify.createNotify(3L, user1, team, "죄송합니다", "");
+
+        // when
+        Long id = notifyService.create(notify);
+
+        // then
+        assertEquals(notify, notifyRepository.findById(id).orElse(null));
+    }
+
+    @Test
+    public void 알림삭제() throws Exception {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        TeamMember teamMember1 = TeamMember.createTeamMember(team, user1, LocalDate.now());
+        teamMemberRepository.save(teamMember1);
+
+        Notify notify = Notify.createNotify(3L, user1, team, "죄송합니다", "");
+        Long id = notifyService.create(notify);
+
+        // when
+        notifyService.delete(id);
+
+        // then
+        assertFalse(notifyRepository.findById(id).isPresent());
+    }
+
+    @Test
+    public void user수신알림조회() throws Exception {
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Notify notify1 = Notify.createNotify(3L, user2, null, "죄송합니다", "");
+        Notify notify2 = Notify.createNotify(3L, user1, null, "아니에요 괜찮습니다.", "");
+        Notify notify3 = Notify.createNotify(3L, user1, null, "아니에요 괜찮습니다.", "");
+        notifyRepository.save(notify1);
+        notifyRepository.save(notify2);
+        notifyRepository.save(notify3);
+
+        UserNotify userNotify1 = UserNotify.createUserNotify(user1, notify1, LocalDate.now());
+        UserNotify userNotify2 = UserNotify.createUserNotify(user2, notify2, LocalDate.now());
+        UserNotify userNotify3 = UserNotify.createUserNotify(user2, notify3, LocalDate.now());
+
+        userNotifyRepository.save(userNotify1);
+        userNotifyRepository.save(userNotify2);
+        userNotifyRepository.save(userNotify3);
+
+        // when
+        List<Notify> userNotifies = notifyService.findAllByUser(user1);
+        List<Notify> userNotifies2 = notifyService.findAllByUser(user2);
+        assertEquals(1, userNotifies.size());
+        assertEquals(2, userNotifies2.size());
+    }
+
+    @Test
+    public void user에게알림전송() throws Exception {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        TeamMember teamMember1 = TeamMember.createTeamMember(team, user1, LocalDate.now());
+        teamMemberRepository.save(teamMember1);
+
+        Notify notify = Notify.createNotify(3L, user1, team, "죄송합니다", "");
+        notifyRepository.save(notify);
+
+        // when
+        notifyService.sendNotify(user2, notify);
+
+        // then
+        List<Notify> userNotifies = notifyService.findAllByUser(user2);
+        assertEquals(1, userNotifies.size());
+    }
+}

--- a/src/test/java/com/springmvc/unid/service/TeamServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/TeamServiceTest.java
@@ -1,0 +1,321 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.domain.*;
+import com.springmvc.unid.repository.*;
+import com.springmvc.unid.util.exception.CustomException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class TeamServiceTest {
+
+    @Autowired TeamService teamService;
+    @Autowired UserRepository userRepository;
+    @Autowired TeamRepository teamRepository;
+    @Autowired TeamMemberRepository teamMemberRepository;
+
+    @Test
+    public void 팀생성(){
+        // given
+        User user1 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+
+        // when
+        Long id = teamService.createTeam(team);
+
+        // then
+        assertEquals(team, teamRepository.findById(id).orElse(null));
+    }
+
+    @Test(expected = CustomException.class)
+    public void 중복_팀명_예외(){
+        // given
+        User user1 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team2 = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+
+        // when
+        teamService.createTeam(team);
+        teamService.createTeam(team2); // 예외가 발생해야 한다.
+    }
+
+    @Test
+    public void 팀정보수정(){
+        // given
+        User user1 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        // when
+        teamService.update(team.getId(), "teamName2", "let's go2", "we find the future2", "www.kakao.com");
+
+        // then
+        assertEquals("teamName2", team.getName());
+    }
+
+    @Test
+    public void 팀삭제(){
+        // given
+        User user1 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+
+        Team team = Team.createTeam("team1", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team2 = Team.createTeam("team2", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+        teamRepository.save(team2);
+
+        // when
+        teamService.deleteTeam(team, user1);
+
+        // then
+        List<Team> findTeam = teamRepository.findByName("team1");
+        assertEquals(0, findTeam.size());
+    }
+
+    @Test
+    public void 팀가입(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        // when
+        teamService.joinTeam(user2, team.getId());
+        teamService.joinTeam(user3, team.getId());
+
+        // then
+        List<TeamMember> teamMembers = teamMemberRepository.findByTeam(team);
+        List<User> users = new ArrayList<>();
+        for(TeamMember teamMember : teamMembers){
+            users.add(teamMember.getUser());
+        }
+        assertEquals(2, users.size());
+    }
+
+    @Test
+    public void 팀탈퇴(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        // when
+        teamService.joinTeam(user2, team.getId());
+        teamService.joinTeam(user3, team.getId());
+        teamService.joinTeam(user4, team.getId());
+
+        teamService.leaveTeam(user2, team.getId());
+        teamService.leaveTeam(user3, team.getId());
+
+        // then
+        List<TeamMember> teamMembers = teamMemberRepository.findByTeam(team);
+        List<User> users = new ArrayList<>();
+        for(TeamMember teamMember : teamMembers){
+            users.add(teamMember.getUser());
+        }
+        assertEquals(1, users.size());
+    }
+
+    @Test
+    public void 팀장변경() {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        // when
+        teamService.setTeamLeader(user1, user2, team.getId());
+
+        // then
+        assertEquals(user2, team.getUser());
+    }
+
+    @Test
+    public void 팀요구사항추가() {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        // when
+        Requirement re = Requirement.createRequirement("backend", team, 3L, "스프링 경험자");
+        teamService.addRequirement(user1.getId(), re);
+
+        // then
+        assertEquals(1, team.getRequirementList().size());
+    }
+
+    @Test(expected = CustomException.class)
+    public void 팀장만_요구사항_접근_가능(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        Requirement re = Requirement.createRequirement("backend", team, 3L, "스프링 경험자");
+        teamService.addRequirement(user1.getId(), re);
+
+        // when
+        Requirement re2 = Requirement.createRequirement("AI", team, 1L, "머신러닝 우대");
+        teamService.addRequirement(user2.getId(), re2); // 팀장이 아니므로 실패해야 함
+    }
+
+    @Test
+    public void 팀요구사항수정() {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        Requirement re = Requirement.createRequirement("backend", team, 3L, "스프링 경험자");
+        Long id = teamService.addRequirement(user1.getId(), re);
+
+        // when
+        Requirement re2 = Requirement.createRequirement("AI", team, 1L, "머신러닝 우대");
+        teamService.updateRequirement(user1.getId(), id, re2);
+
+        // then
+        assertEquals("AI", team.getOneRequirement(re.getId()).getPosition());
+    }
+
+    @Test
+    public void 팀요구사항제거() {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        Requirement re = Requirement.createRequirement("backend", team, 3L, "스프링 경험자");
+        teamService.addRequirement(user1.getId(), re);
+
+        // when
+        teamService.removeRequirement(user1.getId(), re);
+
+        // then
+        assertEquals(0, team.getRequirementList().size());
+    }
+
+    @Test
+    public void user소속대학팀조회(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+
+        Team team1 = Team.createTeam("teamName1", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team2 = Team.createTeam("teamName2", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team3 = Team.createTeam("teamName3", user1, "let's go", "we find the future", "KU", "www.naver.com");
+        Team team4 = Team.createTeam("teamName4", user1, "let's go", "we find the future", "KU", "www.naver.com");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+        teamRepository.save(team3);
+        teamRepository.save(team4);
+
+        // when
+        List<Team> teams = teamService.findTeamByUniv("CAU");
+
+        // then
+        assertEquals(2, teams.size());
+    }
+
+    @Test
+    public void user팀장인팀조회(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team1 = Team.createTeam("teamName1", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team2 = Team.createTeam("teamName2", user2, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team3 = Team.createTeam("teamName3", user3, "let's go", "we find the future", "KU", "www.naver.com");
+        Team team4 = Team.createTeam("teamName4", user4, "let's go", "we find the future", "KU", "www.naver.com");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+        teamRepository.save(team3);
+        teamRepository.save(team4);
+
+        // when
+        List<Team> teams = teamService.findTeamByLeader(user1);
+
+        // then
+        assertEquals(1, teams.size());
+    }
+
+    @Test
+    public void user소속된팀조회(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team1 = Team.createTeam("teamName1", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        Team team2 = Team.createTeam("teamName2", user2, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+
+        teamMemberRepository.save(TeamMember.createTeamMember(team1, user1, LocalDate.now()));
+        teamMemberRepository.save(TeamMember.createTeamMember(team1, user2, LocalDate.now()));
+        teamMemberRepository.save(TeamMember.createTeamMember(team1, user3, LocalDate.now()));
+        teamMemberRepository.save(TeamMember.createTeamMember(team2, user1, LocalDate.now()));
+
+        // when
+        List<Team> teams = teamService.findTeamByUser(user1);
+
+        // then
+        assertEquals( 2, teams.size());
+    }
+}

--- a/src/test/java/com/springmvc/unid/service/UserServiceTest.java
+++ b/src/test/java/com/springmvc/unid/service/UserServiceTest.java
@@ -1,0 +1,208 @@
+package com.springmvc.unid.service;
+
+import com.springmvc.unid.domain.*;
+import com.springmvc.unid.repository.*;
+import com.springmvc.unid.util.exception.CustomException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    UserNotifyRepository userNotifyRepository;
+    @Autowired
+    NotifyRepository notifyRepository;
+    @Autowired
+    TeamRepository teamRepository;
+    @Autowired
+    TeamMemberRepository teamMemberRepository;
+
+    @Test
+    public void 회원가입(){
+        //given
+        User user = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+
+        // when
+        Long id = userService.join(user);
+
+        // then
+        assertEquals(user, userRepository.findById(id).orElse(null));
+    }
+
+    @Test
+    public void 로그인(){
+        //given
+        User user = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userService.join(user);
+
+        // when
+        Long id = userService.login("LoginId", "password");
+
+        // then
+        assertEquals(user, userRepository.findById(id).orElse(null));
+    }
+
+    @Test(expected = CustomException.class)
+    public void 중복_회원_예외(){
+        //given
+        User user1 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+
+        //when
+        userService.join(user1);
+        userService.join(user2); //예외가 발생해야 한다!!!
+
+        //then
+        fail("예외가 발생해야 한다.");
+    }
+
+    @Test
+    public void 회원정보수정(){
+        //given
+        User user = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userService.join(user);
+
+        // when
+        userService.update(user.getId(), "newName", "newPassword", "KU", "EE", "www.kakao.com");
+
+        // then
+        assertEquals("newName", userRepository.findById(user.getId()).orElse(null).getName());
+    }
+
+    @Test
+    public void 회원탈퇴(){
+        //given
+        User user = User.createUser("LoginId", "name", "password", "CAU", "CSE", "www.naver.com");
+        userService.join(user);
+
+        // when
+        userService.delete(user.getId());
+
+        // then
+        assertNull(userRepository.findById(user.getId()).orElse(null));
+    }
+
+    @Test
+    public void 특정대학소속회원조회(){
+        //given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        User user5 = User.createUser("LoginId5", "name5", "password5", "KU", "CSE", "www.naver.com");
+        User user6 = User.createUser("LoginId6", "name6", "password6", "KU", "CSE", "www.naver.com");
+        User user7 = User.createUser("LoginId7", "name7", "password7", "KU", "CSE", "www.naver.com");
+        User user8 = User.createUser("LoginId8", "name8", "password8", "KU", "CSE", "www.naver.com");
+        User user15 = User.createUser("LoginId15", "name15", "password15", "KU", "CSE", "www.naver.com");
+
+        List<User> KUmembers = new ArrayList<>();
+        KUmembers.add(user5);
+        KUmembers.add(user6);
+        KUmembers.add(user7);
+        KUmembers.add(user8);
+        KUmembers.add(user15);
+
+        // when
+        userService.join(user1);
+        userService.join(user2);
+        userService.join(user3);
+        userService.join(user4);
+        userService.join(user5);
+        userService.join(user6);
+        userService.join(user7);
+        userService.join(user8);
+        userService.join(user15);
+
+        // then
+        assertEquals(KUmembers, userService.findUsersByUniversity("KU"));
+    }
+
+    @Test
+    public void 특정팀소속회원조회(){
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        TeamMember teamMember1 = TeamMember.createTeamMember(team, user1, LocalDate.now());
+        TeamMember teamMember2 = TeamMember.createTeamMember(team, user2, LocalDate.now());
+        teamMemberRepository.save(teamMember1);
+        teamMemberRepository.save(teamMember2);
+
+        List<User> teamMembers = new ArrayList<>();
+        teamMembers.add(user1);
+        teamMembers.add(user2);
+
+        // when
+        List<User> teamMembersDB = userService.findUsersByTeam(team);
+
+        // then
+        assertEquals(teamMembers, teamMembersDB);
+    }
+
+    @Test
+    public void 특정알림수신회원조회() {
+        // given
+        User user1 = User.createUser("LoginId1", "name1", "password1", "CAU", "CSE", "www.naver.com");
+        User user2 = User.createUser("LoginId2", "name2", "password2", "CAU", "CSE", "www.naver.com");
+        User user3 = User.createUser("LoginId3", "name3", "password3", "CAU", "CSE", "www.naver.com");
+        User user4 = User.createUser("LoginId4", "name4", "password4", "CAU", "CSE", "www.naver.com");
+        userRepository.save(user1);
+        userRepository.save(user2);
+        userRepository.save(user3);
+        userRepository.save(user4);
+
+        Team team = Team.createTeam("teamName", user1, "let's go", "we find the future", "CAU", "www.naver.com");
+        teamRepository.save(team);
+
+        Notify notify1 = Notify.createNotify(3L, user1, team, "안녕하세요 소통해요", "www.naver.com");
+        notifyRepository.save(notify1);
+
+        UserNotify userNotify1 = UserNotify.createUserNotify(user2, notify1, LocalDate.now());
+        UserNotify userNotify2 = UserNotify.createUserNotify(user3, notify1, LocalDate.now());
+        userNotifyRepository.save(userNotify1);
+        userNotifyRepository.save(userNotify2);
+
+        HashSet<String> notifyUsers = new HashSet<>();
+        notifyUsers.add(user2.getLoginId());
+        notifyUsers.add(user3.getLoginId());
+
+        // when
+        HashSet<String> notifyUsersDB = new HashSet<>();
+        List<User> notifyUsersDBList = userService.findUsersByUserNotify(notify1);
+        for (User user : notifyUsersDBList) {
+            notifyUsersDB.add(user.getLoginId());
+        }
+
+        // then
+        assertEquals(notifyUsers, notifyUsersDB);
+        // 순서가 중요한게 아니라면 Set으로 둘의 내용물이 동일하다는 것을 판정하는 것도 좋을 것 같다.
+    }
+
+}


### PR DESCRIPTION
# 프로젝트 기간(7/1 ~7/14)
* Springboot(Java 11)과 mySQL을 활용한, User-Team-Notify의 주요 3요소로 구성된 프로젝트입니다.
* 유저는 팀에 가입하기 위해 팀장에게 알림을 보낼 수 있고, 팀장은 이에 답장할 수 있습니다. 물론 팀을 탈퇴할 수도 있습니다.
* Notify는 일종의 메일함..을 구현하고자 노력했는데, 초반 설계가 미흡해 Team이 외래키로 잘못 포함되는 바람에 의존성이 크게 늘어나는 문제가 있었습니다.
* 팀은 각 파트별 구인 요구사항을 작성, 수정, 삭제할 수 있습니다.

# 문제점
* 솔로 프로젝트여서 util-controller-service-repository-exception-domain으로 구성되는 패키지를 단일로 설정했습니다. 다른 팀원들과 협업할 때는 주요 기능별로 분리하는 것이 바람직하다고 인지하고 있습니다.
* Controller가 Service를 여러 개 가지는(의존하는) 것이 바람직한지, 아니면 Service가 여러 Repository를 가지는 것이 바람직한지 잘 모르겠습니다. 계층별 역할에 대한 구체적인 고민이 부재했던 프로젝트였습니다. 그 탓에 Service별로 중복되는 Repository가 많습니다.
* Domain-Repository-Service-Test-Dto-Exception-Controller 순으로 독학하면서 진행했는데, Controller에서 클라이언트에게 요청 받아서 사용될 Dto에 대해 고민하지 않아서 Service의 매개변수 등을 대폭 수정해야 했던 문제점이 있었습니다.
* 중간에 김영한 강사님의 JPA 강의를 수강하고 다시 재개했는데, Dto -> Entity를 Controller에서 진행하셨습니다. 우테코나 실무에서는 Dto -> Entity나 Entity -> Dto를 Service에서 주로 하는지, Controller에서 주로 하는지 알고 싶습니다.
<img width="975" alt="image" src="https://github.com/win-luck/UniD_API/assets/53044069/ce40c8c3-5da4-42f5-92eb-d0809a521791">
* 또한 위와 같이 Controller에서 보시면 알 수 있듯이, 값을 반환하는 메서드에 대해 null이 반환되었을 때(즉 팀이 존재하지 않을 때) 에 대한 예외처리를 Controller에서 처리하지 않고 Service의 CumstomException을 활용해 보다 더 깔끔하게 처리하여 클라이언트에게 관련 메시지를 전달하고 싶은데, 바람직한 방법을 찾고 있습니다.
<img width="939" alt="image" src="https://github.com/win-luck/UniD_API/assets/53044069/47bf7755-61e9-4cad-8142-39202207116d">
* 그리고 다대다 관계로 인해 생성되는 중간 테이블에 대한 정보를 확인해야 할 때, (예를 들어 user가 받은 notify 조회, user가 소속된 team 조회) 기능 구현을 위해 다른 Service까지 끌고 왔는데, Service에 관련 Repository를 보강하고 추가적인 Service를 없애는 게 나을까요? 즉 위에서 언급드린 대로 Controller가 의존하는 Service는 줄이고, 대신 Service가 의존하는 Repository를 늘리는 게 더 나은지 알고 싶습니다.
* 클라이언트에 대한 구체적인 생각 없이 (이렇게 보내줄 것이다~)라고 간주하고 시작했던 프로젝트였지만, 앞으로 프런트엔드와 소통하면서 협업해야 할 일이 많을 텐데, 우테코는 매주 과제에서 프런트엔드와 협업하는 것으로 알고 있습니다. 조언 주시면 감사하겠습니다:)